### PR TITLE
Improve error handling and stability for Jenkins Plugin

### DIFF
--- a/src/main/java/io/jenkins/plugins/sdelements/SDElements.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/SDElements.java
@@ -94,8 +94,6 @@ public class SDElements extends Publisher implements SimpleBuildStep {
                 } catch (UnhandledSDLibraryException unhandled) {
                     taskListener.getLogger().println(unhandled.getMessage());
                     LOG.log(Level.SEVERE, "Unhandled error caught", unhandled);
-                    LOG.log(Level.INFO, unhandled.getMessage());
-                    LOG.log(Level.INFO, unhandled.getCause().getMessage());
                 } catch (SDLibraryException ex) {
                     taskListener.getLogger().println(ex.getMessage());
                     LOG.log(Level.WARNING, "Exception for SD Elements", ex);

--- a/src/main/java/io/jenkins/plugins/sdelements/SDElements.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/SDElements.java
@@ -94,6 +94,8 @@ public class SDElements extends Publisher implements SimpleBuildStep {
                 } catch (UnhandledSDLibraryException unhandled) {
                     taskListener.getLogger().println(unhandled.getMessage());
                     LOG.log(Level.SEVERE, "Unhandled error caught", unhandled);
+                    LOG.log(Level.INFO, unhandled.getMessage());
+                    LOG.log(Level.INFO, unhandled.getCause().getMessage());
                 } catch (SDLibraryException ex) {
                     taskListener.getLogger().println(ex.getMessage());
                     LOG.log(Level.WARNING, "Exception for SD Elements", ex);

--- a/src/main/java/io/jenkins/plugins/sdelements/SDElementsActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/SDElementsActionFactory.java
@@ -7,22 +7,46 @@ import hudson.model.Run;
 import jenkins.model.TransientActionFactory;
 
 import javax.annotation.Nonnull;
+import java.lang.System;
+import java.lang.Thread;
+import java.util.concurrent.TimeUnit;
 import java.util.Collection;
 import java.util.Collections;
+
+
 
 /**
  * Creates our action for showing and displaying current status.
  */
 @Extension
 public class SDElementsActionFactory extends TransientActionFactory<Job> {
+    // seconds to wait for a complete build
+    private static final int TIMEOUT = 10;
+    // milliseconds to wait between build checks
+    private static final int INTERVAL = 1000;
+
     @Override
     public Class<Job> type() {
         return Job.class;
     }
 
+    private void waitForBuild(@Nonnull Job job, int timeout) throws InterruptedException {
+        long timeStarted = System.currentTimeMillis();
+        long timeoutMs = TimeUnit.SECONDS.toMillis(timeout);
+
+        while (job.getLastCompletedBuild() == null && System.currentTimeMillis() - timeStarted < timeoutMs) {
+            Thread.sleep(INTERVAL);
+        }
+    }
+
     @Nonnull
     @Override
     public Collection<? extends Action> createFor(@Nonnull Job job) {
+        try {
+            waitForBuild(job, TIMEOUT);
+        } catch (InterruptedException e) {
+            // sleep was interrupted, continue
+        }
         Run<?,?> r = job.getLastCompletedBuild();
         SDElementsRiskIndicatorBuildAction sdba = r.getAction(SDElementsRiskIndicatorBuildAction.class);
         SDElementsRiskIndicatorProjectAction sdpa = new SDElementsRiskIndicatorProjectAction(sdba.getRiskIndicator(), sdba.getProjectUrl(), sdba.getBaseUrl());

--- a/src/main/java/io/jenkins/plugins/sdelements/api/SDElementsLibrary.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/api/SDElementsLibrary.java
@@ -11,7 +11,6 @@ import org.json.JSONException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 
 public class SDElementsLibrary {

--- a/src/main/java/io/jenkins/plugins/sdelements/api/SDElementsLibrary.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/api/SDElementsLibrary.java
@@ -34,7 +34,7 @@ public class SDElementsLibrary {
             if(e.getCause() instanceof UnknownHostException) {
                 throw new SDLibraryException("Host not found: "+url, e);
             }
-            else throw new UnhandledSDLibraryException("Unknown error encountered", e);
+            throw new UnhandledSDLibraryException("Unknown exception encountered. Response:\n"+resp.getBody(), e);
         }
         return resp;
     }

--- a/src/main/java/io/jenkins/plugins/sdelements/api/SDElementsLibrary.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/api/SDElementsLibrary.java
@@ -4,11 +4,15 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+
 import org.json.JSONObject;
+import org.json.JSONException;
 
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Objects;
+import java.util.function.Consumer;
+
 
 public class SDElementsLibrary {
 
@@ -21,30 +25,61 @@ public class SDElementsLibrary {
         this.url = Objects.requireNonNull(url, "url must not be null");
     }
 
-    private HttpResponse<JsonNode> getProject(int id) throws SDLibraryException {
+    private JsonNode getProject(int id) throws SDLibraryException {
         String projects = url + "/api/" + apiVersion + "/projects/"+id+"/";
         HashMap<String,String> headers = new HashMap<>();
         headers.put("Accept", "application/json");
         headers.put("Authorization","Token "+accessKey);
-        HttpResponse<JsonNode> resp = null;
+
+        HttpResponse<String> response = null;
         try {
-            resp = Unirest.get(projects).
-                    headers(headers).asJson();
+            response = Unirest.get(projects)
+                              .headers(headers)
+                              .asString();
         } catch (UnirestException e) {
-            if(e.getCause() instanceof UnknownHostException) {
-                throw new SDLibraryException("Host not found: "+url, e);
+           if (e.getCause() instanceof UnknownHostException) {
+                throw new SDLibraryException("Host not found: " + url, e);
             }
-            throw new UnhandledSDLibraryException("Unknown exception encountered. Response:\n"+resp.getBody(), e);
+            String errorMessage = "Unknown exception encountered.";
+            if (e.getCause() != null) {
+                errorMessage = (
+                    errorMessage +
+                    "\nException message: " +
+                    e.getCause().getMessage()
+                );
+            }
+            throw new UnhandledSDLibraryException(errorMessage, e);
         }
-        return resp;
+
+        // attempt to manually parse the original string so we can stil pass
+        // along the original body in case of error.
+        String body = response.getBody();
+        JsonNode node = null;
+        try {
+            node = new JsonNode(body);
+        } catch (JSONException e) {
+            throw new SDLibraryException(
+                "Unable to parse non-JSON API response.: \n" + body,
+                response
+            );
+        }
+
+        // Raise error for any known error conditions for the request
+        int status = response.getStatus();
+        if(status == 404 && node != null && node.getObject().getString("detail").equals("Not found.")) {
+            throw new SDLibraryException("Project with id "+id+" Not found", response);
+        }
+
+        if(status == 401 && node != null && node.getObject().getString("detail").equals("Invalid token.")) {
+            throw new SDLibraryException("Invalid token in credentials", response);
+        }
+
+        return node;
     }
 
     public String getProjectUrl(int id) throws SDLibraryException {
-        HttpResponse<JsonNode> node = getProject(id);
-        if(node.getStatus() == 200) {
-            return node.getBody().getObject().getString("url");
-        }
-        return null;
+        JsonNode node = getProject(id);
+        return node.getObject().getString("url");
     }
 
     /**
@@ -54,27 +89,20 @@ public class SDElementsLibrary {
      * @throws SDLibraryException when we determine that we didn't get a correct result from SDElements. Empty result, or access denied
      */
     public RiskPolicyCompliance getProjectCompliance(int id) throws SDLibraryException {
-        HttpResponse<JsonNode> node = getProject(id);
-        int status = node.getStatus();
-        JsonNode body = node.getBody();
-        if(status == 404 && body != null && body.getObject().getString("detail").equals("Not found.")) {
-            throw new SDLibraryException("Project with id "+id+" Not found", node);
-        } else if(status == 401 && body != null && body.getObject().getString("detail").equals("Invalid token.")) {
-            throw new SDLibraryException("Invalid token in credentials", node);
-        } else {
-            JSONObject obj = node.getBody().getObject();
-            if (obj != null) {
-                if (obj.isNull("risk_policy_compliant")) {
-                    return RiskPolicyCompliance.UNDETERMINED;
-                }
-                if (obj.getBoolean("risk_policy_compliant")) {
-                    return RiskPolicyCompliance.PASS;
-                } else {
-                    return RiskPolicyCompliance.FAIL;
-                }
-            } else {
-                throw new UnhandledSDLibraryException("Unknown response detected for project with id: " + id, node);
+        JsonNode node = getProject(id);
+        JSONObject obj = node.getObject();
+
+        if (obj != null) {
+            if (obj.isNull("risk_policy_compliant")) {
+                return RiskPolicyCompliance.UNDETERMINED;
             }
+            if (obj.getBoolean("risk_policy_compliant")) {
+                return RiskPolicyCompliance.PASS;
+            } else {
+                return RiskPolicyCompliance.FAIL;
+            }
+        } else {
+            throw new UnhandledSDLibraryException("Unknown response detected for project with id: " + id);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/sdelements/api/SDLibraryException.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/api/SDLibraryException.java
@@ -18,6 +18,10 @@ public class SDLibraryException extends Exception {
         super(message, cause);
     }
 
+    public SDLibraryException(String message) {
+        super(message);
+    }
+
     @Override
     public String getMessage() {
         if(resp != null) {

--- a/src/main/java/io/jenkins/plugins/sdelements/api/UnhandledSDLibraryException.java
+++ b/src/main/java/io/jenkins/plugins/sdelements/api/UnhandledSDLibraryException.java
@@ -14,4 +14,8 @@ public class UnhandledSDLibraryException extends SDLibraryException {
     public UnhandledSDLibraryException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public UnhandledSDLibraryException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
# Problem

We had some users occasionally encountering error conditions like JSON parsing issues where the previous approach was discarding useful debugging information about what the original response body was. The stack trace would reveal a parsing error but not the original text that was attempted to be parsed.

Similarly we were getting the odd failure of the plugin when builds weren't ready when we tried to perform actions.

# Solution

We have reworked the response to return a string and the JSON is being parsed as a separate step so that if a parse error is encountered we can include the original body in the error message. This required a bit of restructuring the methods as with this approach we had no way of creating an `HttpResponse<JsonNode>` object, so now the bits of error handling that required the response have been pulled into the original `getProject` method and we return JsonNodes for consumption by higher level methods.

We also added a method at the start of the run to wait up to 10 seconds for a completed build to avoid any timing issues. This appears to be reasonable common amongst similar plugins. 